### PR TITLE
feat(ci): add prod deployability gate

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -1,0 +1,42 @@
+name: "Prod build"
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "main"
+  schedule:
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "prod-build-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  prod-build:
+    name: "Prod build"
+    runs-on: "ubuntu-22.04"
+
+    steps:
+      - uses: "actions/checkout@v4"
+
+      - name: "Install CI dependencies"
+        run: ./run ci:install-deps
+
+      - name: "Prod build"
+        run: ./run ci:prod-build
+
+      - name: "Upload prod-build measurements"
+        if: always()
+        uses: "actions/upload-artifact@v4"
+        with:
+          name: "prod-build-measurements"
+          path: |
+            ci/last-run.json
+            ci/baseline.json

--- a/.gitignore
+++ b/.gitignore
@@ -185,5 +185,8 @@ flycheck_*.el
 # LLM scratch / unfinished thinking
 .tmp/
 
+# CI-generated prod-build measurements
+/ci/last-run.json
+
 # Process core dumps
 core

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,7 @@ COPY --chown=elixir:elixir . .
 RUN if [ "${MIX_ENV}" != "dev" ]; then \
   mkdir -p /app/priv/static \
   && cp -r /public/* /app/priv/static/ \
+  && mix compile --warnings-as-errors \
   && mix phx.digest && mix release; fi
 
   

--- a/_PROJECT_DOCS/2026-revival-todo.md
+++ b/_PROJECT_DOCS/2026-revival-todo.md
@@ -2,7 +2,7 @@
 
 Started 2026-05-05 with the branch `frontend-infra` ("Backup from broken mac"). This doc tracks where we are in the bigger arc: get the repo working → clean it up → upgrade deps → merge to main → cold-start hardening → typography redesign.
 
-**Updated:** 2026-05-06 (deps + dependabot done; deploy/ops scope grilled into `AGENTS.md`).
+**Updated:** 2026-05-07 (prod-build/nightly CI gate implemented on `agent/prod-build-gate`; deploy substrate still pending).
 
 ---
 
@@ -26,7 +26,7 @@ Started 2026-05-05 with the branch `frontend-infra` ("Backup from broken mac"). 
 | 2.7 — Triage GitHub vulnerabilities | ✅ done | All 213 historical npm alerts auto-resolved by the Group 5 upgrade (timestamps line up exactly with the push). 0 open, 0 hex/elixir-side advisories. The 48-figure on push was a stale snapshot. |
 | 3 — Deploy/ops scope | 🔄 **active** | `/grill-me` ran 2026-05-06. Vision + objectives + 6 strategies in `AGENTS.md`. Hard-constraints + taste-seeding cut short — re-run `/grill-me` next time. |
 | 3.1 — Content-pipeline sync | ⏸ next | `personal-website-content` webhook hardening. PM rank #1 — site is meaningless without content. |
-| 3.2 — CI gates | ⏸ pending | LLM-mistake catcher. Parallelizable with 3.1. |
+| 3.2 — CI gates | 🔄 in PR | Prod-build gate implemented: release build, migrations up/down/up, `/readyz`, route smoke, RPC introspection, rolling baseline seed, nightly schedule. Promote to required branch protection after the workflow is green on GitHub. |
 | 3.3 — Resource-frugality of the app | ⏸ pending | Measure cold-start, p50, memory, cache-hit rate. Cold-start audit at `.tmp/2026-05-05-upgrade-deep-dive/cold-start.md` queued. **Hardware decision falls out of this, not before.** |
 | 3.4 — Front-edge cache (CDN) | ⏸ pending | `/literature` required before tool selection. |
 | 3.5 — Origin substrate + deploy pipeline | ⏸ pending | `/literature` required. Hardware + blue/green + deploy mechanics. |

--- a/_PROJECT_DOCS/adrs/0001-prod-build-ci-gate.md
+++ b/_PROJECT_DOCS/adrs/0001-prod-build-ci-gate.md
@@ -1,0 +1,346 @@
+# ADR 0001 — Production-build CI gates
+
+**Status:** accepted 2026-05-07.
+**Supersedes:** none.
+**Superseded by:** none.
+
+Implementation-PR scope (workflow yaml + Phoenix readiness controller + entrypoint patch + `ci/` scripts) follows this ADR. Tactical PR-level notes live in `.tmp/`, not here.
+
+## Context
+
+The repo's vision (`AGENTS.md:38-42`) is a portfolio "visitors never see broken … with a deploy pipeline that doesn't require remembering anything six months later. CI catches LLM-authored mistakes before they merge." Today CI runs only `MIX_ENV=test` (`.github/workflows/ci.yml:20-46`). The class of mistakes that surfaces only in `MIX_ENV=prod` — `Mix.env()` called at runtime, missing `:applications` declarations, `runtime.exs` config gaps, `cache_static_manifest` failures, dev-only deps leaking — is invisible until first deploy attempt.
+
+A prod-build CI gate produces *continuous* signal on every PR. It also subsumes one-shot resource-frugality measurement (sub-phase 3.3, tracker `:30`): latency baselines accumulate on the same ruler each commit.
+
+## Deployability contract
+
+For this repo, *deployable* means a specific app artifact and a specific content state can be promoted to an origin without fresh human reasoning. The artifact is not just "whatever is on `main`": it is the tuple of app image digest, app git SHA or release tag, content repo commit SHA, DB migration version, and runtime config generation.
+
+There are four deployability levels:
+
+- **PR deployable**: the proposed app code passes acceptance gates, builds a prod release, boots with image-baked content, serves canonical routes, and stays inside the CI-side speed floor or baseline-drift policy.
+- **Release deployable**: the release tag creates an image that can be identified by tag, SHA, and digest; Release Please can merge only after the required gates pass.
+- **Content deployable**: a `personal-website-content` commit can be authenticated, deduped, synced, parsed, and either promoted or rejected without preventing the app from booting.
+- **Origin deployable**: the selected origin can pull or receive the release artifact, run migrations, flip blue/green, pass live smoke, and roll back to the last known-good app/content pair.
+
+This ADR implements the first level and prepares the second. Content and origin deployability remain follow-up work because they involve the webhook/sync path and the deploy substrate.
+
+## Developer experience
+
+The desired DX is "push, read the verdict, act only when the verdict is actionable."
+
+For app-code work:
+
+- A PR shows the existing acceptance gates plus a separate `prod-build` gate. The failing check name tells whether the problem is test code, static analysis, security, workflow shape, secret scan, or production deployability.
+- When `prod-build` fails, the log points to the failed phase: prod deps, prod compile, assets, release assembly, migration round-trip, boot, readiness, route smoke, RPC introspection, or speed regression.
+- The same gate can run locally as `./run ci:prod-build` once implemented. If a raw lower-level command is used while debugging, the final verdict still comes from the canonical `./run` task.
+- A green PR means "safe to merge into the release automation," not "served to visitors." The deploy substrate and live-origin smoke are later gates.
+
+For release work:
+
+- Conventional commits feed Release Please.
+- Release Please opens or updates the release PR.
+- Auto-merge waits on the required gates, including `prod-build` once promoted to branch protection.
+- A merged release creates an image tagged by release and commit SHA. Future deploy tooling consumes that identity, not a floating local build.
+
+For content work:
+
+- Publishing a blog/content repo change should feel like a content deploy, not an SSH session.
+- The content pipeline records the content commit SHA that the app accepted.
+- If content sync fails, the site keeps serving the previous content state and reports the failed commit.
+- If content is broken after promotion, rollback targets the previous app/content pair or the previous content commit alone.
+
+For nightly work:
+
+- Nightly reruns the prod-build gate against `main` and records speed data.
+- Green nightly runs should be quiet.
+- Red nightly runs should report the failing phase and the last good app/content identity. [Z to fill: notification destination]
+- Nightly does not deploy by itself until origin deployability and rollback gates exist.
+
+The operator experience this ADR rejects: reading raw Actions logs to infer whether a Phoenix release is safe, discovering prod-only failures on the origin, manually remembering which blog commit is live, or treating image `latest` as rollback identity.
+
+## Hard constraints
+
+Binding from `AGENTS.md:65-76` (and global `~/.agents/AGENTS.md` §3 anti-rationalization):
+
+- No tool/stack prescription without `/literature` first. Citations to the run at `.tmp/2026-05-06-phoenix-prod-ci-gate/literature/brief.md` are the basis for every recommendation below; full URLs inlined in the **References** section so the ADR is self-contained when `.tmp/` ages out.
+- Versioned + idempotent deploys.
+- Speed wins ties.
+- Compute-per-watt floor; never at user expense.
+- Touch only what you're asked to touch; one commit, one concern.
+
+Ratified by Z 2026-05-06: ADRs live in `_PROJECT_DOCS/adrs/` and are not embedded in `AGENTS.md`. AGENTS.md is for always-needed direction and workflows + lookup pointers.
+
+## GitHub coupling — kept thin
+
+Principle: the gate is a **shell pipeline that happens to run on GitHub Actions**, not a GitHub-native workflow. If CI migrates off GitHub, the *commands* port unchanged; only the wrapping yaml changes.
+
+| GitHub-specific surface | Load-bearing for | Replaceable with |
+|---|---|---|
+| `actions/checkout@v4` | correctness + portable | `git clone` on any runner |
+| `actions/cache@v4` | optimization-only + portable | local volume, S3, gitlab cache |
+| `services: postgres:` | correctness + portable | `docker run postgres` on any runner |
+| `${{ runner.os }}` interpolation in cache key | optimization-only + portable | hard-coded `linux-x64` outside GH |
+| `${{ hashFiles(...) }}` in cache key | optimization-only + portable | `sha1sum` in shell |
+| `if: failure()` / `if: always()` step-meta | step-meta only + tolerable GH-ism | per-runner equivalent or omit |
+
+Explicitly avoided:
+
+- **No third-party Actions** for gate logic. `oha`, `gitleaks`, future scanners install via direct `curl + tar` of release tarballs (precedent: `.github/workflows/secret-scan.yml`).
+- **No `gh-pages` for baseline storage.** Baseline lives in `ci/baseline.json` checked into the repo (precedent: `.gitleaks.baseline.json` in PR #51).
+- **No GH Check API** beyond standard exit codes.
+- **No GitHub Secret Scanning or Dependabot** dependency.
+- **No load-bearing GH-only artifact storage.** `actions/upload-artifact@v4` uploads exist for human inspection only; the gate's verdict logic never reads them back.
+- **No `${{ github.ref }}` branch conditionals in yaml.** Branch logic lives in `ci/update-baseline.sh`.
+
+**Invariant:** `ci/*.sh` may set the app's existing runtime variables whose names start with `GITHUB_`, such as `GITHUB_WEBHOOK_SECRET`, but it must not consume GitHub Actions-provided `$GITHUB_*` metadata or call the `gh` CLI. That keeps the gate portable without renaming application configuration in this slice.
+
+## Decisions
+
+Each decision is `recommendation from /literature → adoption verdict → citation`. Citations resolve in **References** below.
+
+### Group A — Build pipeline (`MIX_ENV=prod`)
+
+#### deps-prod-only
+
+`MIX_ENV=prod mix deps.get --only prod`. Excludes dev-only deps from the resolved tree; forces dev-only-dep leakage to surface in CI rather than at deploy. Cite `[p101] [p103] [p117]`.
+
+#### compile-warnings-as-errors
+
+`MIX_ENV=prod mix compile --warnings-as-errors`. Catches: `LiveDashboard` referenced from a shared template (`[p115]`), `Mix.env()` at runtime (`[p119]`), compile-time module-attribute bake-in (`[p120]`). Authoritative endorsement: Dashbit `[p118]`. Set `CI: false` for the next step (`[p127]` — JS toolchain treats `CI=true` as warnings-as-errors).
+
+#### assets-deploy
+
+`MIX_ENV=prod mix assets.deploy`. Canonical Phoenix 1.7+ task: bundles esbuild + tailwind with `--minify`, runs `mix phx.digest`, generates `priv/static/cache_manifest.json`. Without this, boot crashes on `cache_manifest.json not found` (`[p121]`).
+
+#### mix-release
+
+`MIX_ENV=prod mix release`. Catches strictly more than compile-only: missing `:applications` (`[p116]`), `runtime.exs`-only failures including `server: true` (`[p114]`), assembly-time path / permission issues. Cite `[p101] [p114] [p116] [p117] [p119]`.
+
+### Group B — Boot harness
+
+#### bypass-content-pull
+
+The release boot script (`bin/docker-entrypoint-web`) currently runs `Portfolio.Release.pull_repository/0` against GitHub. CI must not depend on GitHub.com reachability. Honor `CI_SKIP_CONTENT_PULL=1` in the entrypoint; CI sets it and serves the image-baked `priv/content` snapshot at `/app/priv/content`. Pattern matches `[p102] [p126]`. Localized to the entrypoint script — `CI_SKIP_CONTENT_PULL` MUST NOT leak into application code (avoids dev/prod drift, `[p120]`).
+
+#### runtime-config-discipline
+
+`runtime.exs` MUST use `config_env() == :prod`, never `Mix.env()` (`[p119] [p110]`). Enforced by review until a Credo rule lands (out of scope for this ADR).
+
+#### readiness-endpoint
+
+`GET /readyz` returns 200 OK after `Repo` and `Endpoint` are up. Pattern: `[p102] [p113]`. The 30s retry loop interposed before the smoke and latency-probe steps is a *readiness* check, not a *liveness* check — name is `/readyz` (not `/healthz`) per S5 of the IA/DDD peer-review. `lib/portfolio_web/controllers/readiness_controller.ex` + a route in `router.ex`.
+
+```bash
+for _i in $(seq 1 30); do
+  curl -sf "http://localhost:${APP_PORT:-4000}/readyz" && break || sleep 1
+done
+```
+
+#### migrations-roundtrip
+
+Locked rule per `~/.agents/skills/elixir-phoenix-style/`: migration round-trip in CI on a fresh DB.
+
+```yaml
+- name: Migrations round-trip
+  run: |
+    bin/portfolio eval "Portfolio.Release.migrate()"
+    bin/portfolio eval "Portfolio.Release.rollback(Portfolio.Repo, 1)"
+    bin/portfolio eval "Portfolio.Release.migrate()"
+```
+
+`Portfolio.Release.rollback/2` already exists at `lib/portfolio/release.ex:123` with arity `(repo, version)`. No new code needed for this decision.
+
+### Group C — Measurement
+
+#### latency-probe-tool
+
+`oha` (Rust binary, single static install via release tarball). `oha <url> -n 30 --json --no-tui` outputs p50/p95/p99/min/max/stddev/req-per-second per route. Boring, obvious fit (`[p111]`). Reject `curl` bash loop (fragile parsing), reject `k6`/`playwright` (overkill), `wrk`/`hey` are inferior to `oha`. **N=30 per route**, not N=10 — the academic floor for stable p50 estimates on noisy infrastructure (`[p108]`).
+
+#### perf-budget-policy
+
+The 200ms p50 figure (`AGENTS.md:53`, sub-phase 3.3 frugality target) stays valid as the *production* target. Enforced as an absolute gate on `ubuntu-latest` it is structurally fragile: 2.66% CV (`[p105]`), CPU-SKU rotation 5–10% across runs (`[p106]`).
+
+Adopted CI-side policy:
+
+- **Absolute floor: 1000ms p50** (5× the production target; catches catastrophic regressions only).
+- **Rolling-30-main-branch median + 20% drift** (catches creeping regressions).
+- **Disabled until 30 main-branch runs accumulate.**
+
+Cite `[p108] [p122] [p123] [p124]`.
+
+#### cold-start-measurement
+
+Captured separately from warm p50:
+
+- **Time to ready** — from `bin/portfolio start` to first 200 on `/readyz`.
+- **Cold response** — `oha -n 1 -c 1` on the first request.
+
+Both written to `ci/baseline.json` for trend tracking. Ties to the 400ms cold-start target in the queued cold-start audit (`.tmp/2026-05-05-upgrade-deep-dive/cold-start.md`). Not gated initially.
+
+#### release-rpc-introspection
+
+After the latency probe is green, run `bin/portfolio rpc` against the booted release to confirm:
+
+- `Application.spec(:portfolio, :vsn)` is readable and logged next to the app SHA.
+- Supervision tree intact.
+- `Portfolio.Repo` serves a query.
+
+Adds ~3 seconds; catches "boot ran but app silently degraded" — a class HTTP probes alone don't cover (`[p112] [p125]`).
+
+### Group D — Persistence
+
+#### latency-baseline-file
+
+`ci/baseline.json` (durable, repo-checked, updated on main only). Schema in repo's vocabulary, **not** `oha`'s output shape (avoids conformist anti-pattern):
+
+```json
+{
+  "runs_count": <int>,
+  "routes": {
+    "/en": {"warm_p50_ms": <int>, "warm_p95_ms": <int>, "cold_first_ms": <int>, ...},
+    ...
+  },
+  "ready_ms_median": <int>,
+  "last_updated_main_sha": "<sha>"
+}
+```
+
+The `ci/update-baseline.sh` script translates `oha`'s output into this schema; if `oha` ships v2 with renamed fields, the translation step changes, not the baseline file format.
+
+When `runs_count >= 30`, the perf-budget gate transitions from disabled (logging-only) to enforcing.
+
+#### routes-known-broken
+
+`ci/routes-known-broken.txt`, one route per line, with a `# why:` comment per entry. Initial state: empty. New failures fix-or-revert; deferring requires explicit edit + justification commit. *Not* a ratchet — additions are allowed but require ceremony; the file is an exemption list, not a monotone-shrinking pile.
+
+## Workflow shape (concrete)
+
+```yaml
+name: "Prod build"
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+  schedule:
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+
+jobs:
+  prod-build:
+    name: "Prod build"
+    runs-on: "ubuntu-22.04"
+
+    steps:
+      - uses: "actions/checkout@v4"
+      - name: "Install CI dependencies"
+        run: ./run ci:install-deps
+      - name: "Prod build"
+        run: ./run ci:prod-build
+      - name: "Upload prod-build measurements"
+        if: always()
+        uses: "actions/upload-artifact@v4"
+        with:
+          name: "prod-build-measurements"
+          path: |
+            ci/last-run.json
+            ci/baseline.json
+```
+
+`ci/prod-build.sh` owns the release build, migration round-trip, boot, readiness wait, route probe, RPC introspection, comparison, and baseline update. `ci/probe-routes.sh`, `ci/compare.sh`, and `ci/update-baseline.sh` are thin shell wrappers around `oha` and `jq`. They contain all branch conditionals (`update-baseline.sh` exits 0 unless on `main`) and translate `oha`-shaped JSON into the repo-native baseline schema.
+
+## Mistake classes caught
+
+| Mistake class | Caught by |
+|---|---|
+| Dev-only dep referenced in shared template | compile-warnings-as-errors (`[p115]`) |
+| `Mix.env()` called at runtime in a release | mix-release boot — crashes on first call (`[p119]`) |
+| `server: true` missing from `runtime.exs` | readiness-endpoint wait — port doesn't bind (`[p114]`) |
+| Compile-time module-attribute bakes wrong value | latency-probe-tool — wrong response (`[p120]`) |
+| `:applications` vs `:extra_applications` mistake | mix-release — load failure (`[p116]`) |
+| `cache_static_manifest` missing | prevented by assets-deploy (`[p121]`) |
+| Migration ran but cannot roll back | migrations-roundtrip |
+| Boot succeeded but supervision tree silently degraded | release-rpc-introspection |
+| Deps resolution leaks dev-only deps to prod tree | deps-prod-only |
+| Slow regression below catastrophic floor (1000ms+) | perf-budget-policy floor |
+| Creeping regression (>20% drift over rolling-30 main median) | perf-budget-policy drift gate |
+| Newly-broken canonical route on a PR | latency-probe-tool + routes-known-broken (no entry → fail) |
+
+## What this gate doesn't catch
+
+- Multi-arch image differences (sub-phase 3.5 — deploy substrate).
+- Deploy-time concerns: blue/green flip, post-deploy smoke against live origin, traffic-served verification.
+- Observability concerns (sub-phase 3.6).
+- Real GitHub-webhook integration (sub-phase 3.1).
+
+## Open questions / future work
+
+- **Compile-time-only-value lint** — Credo rule for `Application.compile_env/3` misuse (`[p110] [p120]`). Out of scope for this ADR.
+- **Cache reset on retry hygiene** (`[p104]`). Over-engineered for personal-site scale; revisit if flakes appear.
+- **Multi-arch latency probe** — when sub-phase 3.5 lands, decide between QEMU-on-ARM (slow, exact) and trust-multi-arch-image-equivalence (fast, cogini-style `[p102]`).
+- **`bench/` for actual `mix bench` benchmarks** — directory deliberately reserved by this ADR's choice of `ci/`.
+
+## Caveats
+
+The literature peer-review run at `.tmp/2026-05-06-phoenix-prod-ci-gate/literature/brief.md` has no published `ubuntu-latest` Phoenix HTTP-loop CV/latency benchmark. The first 30 main-branch runs *populate* the rolling baseline; the 1000ms floor and 20% drift threshold are derived defaults — **revisit when `ci/baseline.json` `runs_count >= 30`**, tracked as a self-trigger inside the baseline file.
+
+## References
+
+Each `[pNNN]` resolves to a primary source. Inlined here so the ADR is self-contained when `.tmp/` ages out.
+
+| ID | Source | URL | One-line claim used |
+|----|--------|-----|---------------------|
+| `[p101]` | Phoenix Releases hexdocs | https://hexdocs.pm/phoenix/releases.html | Canonical Phoenix release-task contract; `mix release` + `assets.deploy` shape |
+| `[p102]` | cogini/phoenix_container_example | https://github.com/cogini/phoenix_container_example | Reference prod-build CI pattern; readiness probe loop; CI-only entrypoint guards |
+| `[p103]` | Richard Taylor — Elixir/Phoenix release workflow | https://richard.dev/articles/elixir-phoenix-release-workflow | `--only prod` discipline; release-vs-test pipeline split |
+| `[p104]` | Felt — Hashrocket Ultimate Elixir CI | https://feltdev.com/blog/ultimate-elixir-ci | Cache-reset-on-retry as flake hygiene |
+| `[p105]` | CodSpeed — runner noise study | https://codspeed.io/articles/runner-noise | 2.66% CV measured on `ubuntu-latest` |
+| `[p106]` | CodSpeed — GLIBC variance | https://codspeed.io/articles/glibc-variance | CPU-SKU rotation effect on ubuntu-latest baseline |
+| `[p108]` | arxiv 2408.08148 — early perf regression detection | https://arxiv.org/abs/2408.08148 | N=30 per measurement at component level for stable p50 |
+| `[p110]` | ElixirForum — runtime.exs gotchas | https://elixirforum.com/t/runtime-exs-config-gotchas | `config_env()` not `Mix.env()` discipline |
+| `[p111]` | oha vs hey vs wrk vs k6 vs bombardier | https://github.com/hatoo/oha#comparison | `oha` JSON output shape; single static binary |
+| `[p112]` | cogini — K8s health checks for Elixir | https://github.com/cogini/elixir-health-checks | Readiness vs liveness probe split |
+| `[p113]` | jola — Plug+Phoenix health checks | https://hexdocs.pm/jola/readme.html | `/readyz` retry loop pattern |
+| `[p114]` | Phoenix issue #4695 — `server: true` in runtime.exs | https://github.com/phoenixframework/phoenix/issues/4695 | release "starts" but doesn't bind port if `server: true` missing |
+| `[p115]` | Phoenix issue #4080 — LiveDashboard prod warning | https://github.com/phoenixframework/phoenix/issues/4080 | Dev-only dep referenced from shared template fires only in `MIX_ENV=prod` |
+| `[p116]` | AmberBit — mix release missing deps | https://amberbit.com/blog/mix-release-missing-deps | `:applications` vs `:extra_applications` mistakes; release-assembly catch |
+| `[p117]` | Codemancers — Phoenix release nuances | https://codemancers.com/blog/phoenix-release-nuances | runtime.exs evaluated only at release boot |
+| `[p118]` | Dashbit — warnings as errors | https://dashbit.co/blog/warnings-as-errors | Authoritative `--warnings-as-errors` endorsement |
+| `[p119]` | ElixirForum — Mix.env runtime crash | https://elixirforum.com/t/mix-env-runtime-crash | `Mix.env()` masked in `MIX_ENV=test`, crashes in release |
+| `[p120]` | Felt — Elixir configuration tips | https://feltdev.com/blog/elixir-configuration-tips | `Application.compile_env/3` discipline |
+| `[p121]` | Phoenix asset pipeline + cache_static_manifest | https://hexdocs.pm/phoenix/asset_management.html | `cache_manifest.json not found` boot crash if `assets.deploy` skipped |
+| `[p122]` | Bencher.dev — continuous benchmarking | https://bencher.dev/docs/explanation/thresholds/ | Rolling baseline + drift threshold pattern |
+| `[p123]` | github-action-benchmark | https://github.com/benchmark-action/github-action-benchmark | Default 200% drift gate; `gh-pages` vs in-repo baseline |
+| `[p124]` | OneUptime — perf testing in GitHub Actions | https://oneuptime.com/blog/perf-testing-github-actions | N=100 with hyperfine; warm-up phase rule |
+| `[p125]` | ElixirForum — `start_iex` / `rpc` | https://elixirforum.com/t/release-rpc-introspection | `bin/<app> rpc` introspection pattern |
+| `[p126]` | Phoenix Railway nixpacks skip-migrate | https://railway.app/docs/phoenix-nixpacks | "skip migrate during build" idiom |
+| `[p127]` | GitHub #25228 — `CI=true` warnings as errors | https://github.com/actions/runner/issues/25228 | JS toolchain treats `CI=true` as warnings-as-errors |
+| `[p128]` | cogini — best practices deploying Elixir | https://www.cogini.com/blog/best-practices-deploying-elixir-apps | Ubuntu/Debian over Alpine for Elixir release |
+
+(Manifest of all 30 sources, including those not cited here, is at `.tmp/2026-05-06-phoenix-prod-ci-gate/literature/manifest.md`. Manifest will be cleaned up when `.tmp/` ages out; the URLs above are the durable record.)
+
+## Pointers
+
+- `AGENTS.md:9-23` — acceptance gates (this ADR's gates extend the family).
+- `AGENTS.md:38-42` — vision.
+- `AGENTS.md:53` — strategy #2 (CI gates).
+- `AGENTS.md:92` — ADR routing rule (amended same commit).
+- `_PROJECT_DOCS/2026-revival-todo.md:29` — sub-phase 3.2 row (links to this ADR).
+- `.github/workflows/ci.yml` — existing `MIX_ENV=test` pipeline.
+- `.github/workflows/secret-scan.yml` (PR #51) — gitleaks gate; baseline-file pattern precedent.
+- `.gitleaks.baseline.json` — durable-baseline-file shape this ADR borrows.
+- `bin/docker-entrypoint-web:43-52` — current boot sequence (will honor `CI_SKIP_CONTENT_PULL`).
+- `lib/portfolio/release.ex:123` — `rollback/2` (already exists; no new code).
+- `lib/portfolio_web/endpoint.ex:18` — exposed HMAC literal (Task #4 op-side; rotation independent of this ADR).
+
+## Implementation PR (follows ratification)
+
+- `.github/workflows/prod-build.yml` (new — workflow above)
+- `lib/portfolio_web/controllers/readiness_controller.ex` + route entry in `router.ex`
+- `bin/docker-entrypoint-web` patch (honor `CI_SKIP_CONTENT_PULL=1`)
+- `ci/probe-routes.sh`, `ci/compare.sh`, `ci/update-baseline.sh`
+- `ci/routes-known-broken.txt` (initial empty)
+- `ci/baseline.json` (initial `{"runs_count": 0, "routes": {}}`)
+
+No application-code changes outside `lib/portfolio_web/controllers/readiness_controller.ex` and the `router.ex` route.

--- a/bin/docker-entrypoint-web
+++ b/bin/docker-entrypoint-web
@@ -45,10 +45,14 @@ if [ -d "/app/releases" ] && [ -f "/app/bin/portfolio" ]; then
         exit 1
     fi
     
-    log "Pulling latest changes from the content repository..."
-    if ! /app/bin/portfolio eval "Portfolio.Release.pull_repository()"; then
-        log "Error: Failed to pull latest changes from the repository"
-        exit 1
+    if [ "${CI_SKIP_CONTENT_PULL:-}" = "1" ]; then
+        log "Skipping content repository pull for CI"
+    else
+        log "Pulling latest changes from the content repository..."
+        if ! /app/bin/portfolio eval "Portfolio.Release.pull_repository()"; then
+            log "Error: Failed to pull latest changes from the repository"
+            exit 1
+        fi
     fi
 elif [ "$MIX_ENV" = "prod" ]; then
     log "MIX_ENV is set to prod, but release files not found. This might be an error."

--- a/ci/baseline.json
+++ b/ci/baseline.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "runs_count": 0,
+  "ready_ms_samples": [],
+  "ready_ms_median": null,
+  "routes": {},
+  "last_updated_main_sha": null
+}

--- a/ci/compare.sh
+++ b/ci/compare.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+LAST_RUN_FILE="${1:-ci/last-run.json}"
+BASELINE_FILE="${2:-ci/baseline.json}"
+ABSOLUTE_P50_FLOOR_MS="${ABSOLUTE_P50_FLOOR_MS:-1000}"
+DRIFT_PERCENT="${DRIFT_PERCENT:-20}"
+MIN_BASELINE_RUNS="${MIN_BASELINE_RUNS:-30}"
+failures=0
+
+if [[ ! -f "${LAST_RUN_FILE}" ]]; then
+    echo "fatal: last-run file not found: ${LAST_RUN_FILE}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${BASELINE_FILE}" ]]; then
+    echo "fatal: baseline file not found: ${BASELINE_FILE}" >&2
+    exit 1
+fi
+
+baseline_runs="$(jq -r '.runs_count // 0' "${BASELINE_FILE}")"
+
+while IFS= read -r route; do
+    status="$(jq -r --arg route "${route}" '.routes[$route].status' "${LAST_RUN_FILE}")"
+    p50="$(jq -r --arg route "${route}" '.routes[$route].warm_p50_ms // 0' "${LAST_RUN_FILE}")"
+
+    if [[ "${status}" == "fail" ]]; then
+        echo "prod-build route failed: ${route}" >&2
+        failures=$((failures + 1))
+        continue
+    fi
+
+    if [[ "${status}" == "known_broken" ]]; then
+        echo "prod-build route known-broken exemption used: ${route}" >&2
+        continue
+    fi
+
+    if (( p50 > ABSOLUTE_P50_FLOOR_MS )); then
+        echo "prod-build route exceeded absolute p50 floor: ${route} p50=${p50}ms floor=${ABSOLUTE_P50_FLOOR_MS}ms" >&2
+        failures=$((failures + 1))
+    fi
+
+    if (( baseline_runs >= MIN_BASELINE_RUNS )); then
+        baseline_p50="$(jq -r --arg route "${route}" '.routes[$route].warm_p50_ms // empty' "${BASELINE_FILE}")"
+
+        if [[ -n "${baseline_p50}" && "${baseline_p50}" != "null" ]]; then
+            drift_limit="$(
+                awk -v base="${baseline_p50}" -v drift="${DRIFT_PERCENT}" 'BEGIN { printf "%.0f", base * (1 + drift / 100) }'
+            )"
+
+            if (( p50 > drift_limit )); then
+                echo "prod-build route exceeded rolling baseline drift: ${route} p50=${p50}ms limit=${drift_limit}ms baseline=${baseline_p50}ms" >&2
+                failures=$((failures + 1))
+            fi
+        fi
+    fi
+done < <(jq -r '.routes | keys[]' "${LAST_RUN_FILE}")
+
+if (( baseline_runs < MIN_BASELINE_RUNS )); then
+    echo "prod-build drift gate logging-only: baseline runs ${baseline_runs}/${MIN_BASELINE_RUNS}"
+fi
+
+if (( failures > 0 )); then
+    exit 1
+fi
+
+echo "prod-build comparison passed"

--- a/ci/probe-routes.sh
+++ b/ci/probe-routes.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+BASE_URL="${PROD_BUILD_BASE_URL:-http://127.0.0.1:18080}"
+OUTPUT_FILE="${1:-ci/last-run.json}"
+OHA_BIN="${OHA_BIN:-oha}"
+OHA_REQUESTS="${OHA_REQUESTS:-30}"
+OHA_CONNECTIONS="${OHA_CONNECTIONS:-1}"
+OHA_TIMEOUT="${OHA_TIMEOUT:-10s}"
+OHA_ATTEMPTS="${OHA_ATTEMPTS:-3}"
+READY_MS="${PROD_BUILD_READY_MS:-null}"
+APP_SHA="${PROD_BUILD_APP_SHA:-$(git rev-parse HEAD)}"
+ROUTES_RAW="${PROD_BUILD_ROUTES:-/ /en /en/case-studies /en/notes /en/self /ja}"
+KNOWN_BROKEN_FILE="${KNOWN_BROKEN_FILE:-ci/routes-known-broken.txt}"
+IFS=" " read -r -a ROUTES <<< "${ROUTES_RAW}"
+
+function is_known_broken {
+    local route="$1"
+    local known_route
+
+    [[ -f "${KNOWN_BROKEN_FILE}" ]] || return 1
+
+    while IFS= read -r known_route || [[ -n "${known_route}" ]]; do
+        known_route="${known_route%%#*}"
+        known_route="${known_route//[[:space:]]/}"
+
+        if [[ "${known_route}" == "${route}" ]]; then
+            return 0
+        fi
+    done < "${KNOWN_BROKEN_FILE}"
+
+    return 1
+}
+
+function oha_json {
+    local attempts="${OHA_ATTEMPTS}"
+    local attempt=1
+    local output
+
+    while (( attempt <= attempts )); do
+        if output="$("${OHA_BIN}" "$@")"; then
+            printf "%s" "${output}"
+            return 0
+        fi
+
+        attempt=$((attempt + 1))
+        sleep 1
+    done
+
+    return 1
+}
+
+function route_result {
+    local route="$1"
+    local url="${BASE_URL}${route}"
+    local cold_json
+    local warm_json
+    local route_status="pass"
+
+    if ! cold_json="$(oha_json -n 1 -c 1 --json --no-tui -t "${OHA_TIMEOUT}" "${url}")"; then
+        route_status="fail"
+        cold_json="{}"
+    fi
+
+    if ! warm_json="$(oha_json -n "${OHA_REQUESTS}" -c "${OHA_CONNECTIONS}" --json --no-tui -t "${OHA_TIMEOUT}" "${url}")"; then
+        route_status="fail"
+        warm_json="{}"
+    fi
+
+    if [[ "${route_status}" == "pass" ]]; then
+        route_status="$(
+            jq -r '
+              def ok_status: test("^[23]");
+              if ((.statusCodeDistribution // {}) | to_entries | map(select(.key | ok_status | not)) | length) == 0
+                 and ((.summary.successRate // 0) == 1)
+              then "pass"
+              else "fail"
+              end
+            ' <<< "${warm_json}"
+        )"
+    fi
+
+    if [[ "${route_status}" == "fail" ]] && is_known_broken "${route}"; then
+        route_status="known_broken"
+    fi
+
+    jq -n \
+        --arg route "${route}" \
+        --arg url "${url}" \
+        --arg status "${route_status}" \
+        --argjson requests "${OHA_REQUESTS}" \
+        --argjson cold "${cold_json}" \
+        --argjson warm "${warm_json}" \
+        '{
+          route: $route,
+          url: $url,
+          status: $status,
+          success_rate: (($warm.summary.successRate // 0) * 100),
+          status_codes: ($warm.statusCodeDistribution // {}),
+          cold_first_ms: (($cold.latencyPercentiles.p50 // 0) * 1000 | round),
+          warm_p50_ms: (($warm.latencyPercentiles.p50 // 0) * 1000 | round),
+          warm_p95_ms: (($warm.latencyPercentiles.p95 // 0) * 1000 | round),
+          warm_p99_ms: (($warm.latencyPercentiles["p99"] // 0) * 1000 | round),
+          requests: $requests
+        }'
+}
+
+result="$(
+    jq -n \
+        --arg schema_version "1" \
+        --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --arg app_sha "${APP_SHA}" \
+        --arg base_url "${BASE_URL}" \
+        --argjson ready_ms "${READY_MS}" \
+        '{
+          schema_version: ($schema_version | tonumber),
+          generated_at: $generated_at,
+          app_sha: $app_sha,
+          base_url: $base_url,
+          ready_ms: $ready_ms,
+          routes: {}
+        }'
+)"
+
+for route in "${ROUTES[@]}"; do
+    route_json="$(route_result "${route}")"
+    result="$(
+        jq \
+            --arg route "${route}" \
+            --argjson route_json "${route_json}" \
+            '.routes[$route] = $route_json' <<< "${result}"
+    )"
+done
+
+mkdir -p "$(dirname "${OUTPUT_FILE}")"
+printf "%s\n" "${result}" > "${OUTPUT_FILE}"
+jq . "${OUTPUT_FILE}"

--- a/ci/prod-build.sh
+++ b/ci/prod-build.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+PROJECT_NAME="${PROD_BUILD_COMPOSE_PROJECT:-personal-site-prod-build}"
+HOST_PORT="${PROD_BUILD_HOST_PORT:-18080}"
+APP_PORT="${PORT:-8000}"
+OHA_VERSION="${OHA_VERSION:-1.4.7}"
+COMPOSE_OVERRIDE_FILE=".tmp/prod-build/compose.override.yml"
+OHA_DOCKER_IMAGE="${OHA_DOCKER_IMAGE:-debian:bookworm-slim}"
+APP_SHA="$(git rev-parse HEAD)"
+compose=(docker compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f "${COMPOSE_OVERRIDE_FILE}")
+
+function now_ms {
+    perl -MTime::HiRes=time -e 'printf "%.0f\n", time() * 1000'
+}
+
+function cleanup {
+    local status=$?
+
+    if [[ "${status}" -ne 0 ]]; then
+        if ! "${compose[@]}" ps; then
+            echo "warning: failed to inspect prod-build compose services" >&2
+        fi
+
+        if ! "${compose[@]}" logs --no-color --tail=200 web postgres; then
+            echo "warning: failed to collect prod-build compose logs" >&2
+        fi
+    fi
+
+    if ! "${compose[@]}" down --volumes --remove-orphans >/dev/null 2>&1; then
+        echo "warning: failed to clean up prod-build compose project" >&2
+    fi
+
+    return "${status}"
+}
+
+function require_command {
+    local command_name="$1"
+
+    if ! command -v "${command_name}" >/dev/null 2>&1; then
+        echo "fatal: required command not found: ${command_name}" >&2
+        exit 1
+    fi
+}
+
+function oha_asset_name {
+    local os="$1"
+    local arch="$2"
+
+    case "${os}-${arch}" in
+        Linux-x86_64 | Linux-amd64)
+            printf "oha-linux-amd64"
+            ;;
+        Linux-aarch64 | Linux-arm64)
+            printf "oha-linux-arm64"
+            ;;
+        Darwin-arm64)
+            printf "oha-macos-arm64"
+            ;;
+        Darwin-x86_64)
+            printf "oha-macos-amd64"
+            ;;
+        *)
+            echo "fatal: unsupported oha platform: ${os}-${arch}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+function download_oha_asset {
+    local asset
+    local target
+
+    asset="$1"
+    target="$2"
+
+    if [[ -x "${target}" ]]; then
+        return 0
+    fi
+
+    mkdir -p "$(dirname "${target}")"
+    curl -fsSL "https://github.com/hatoo/oha/releases/download/v${OHA_VERSION}/${asset}" -o "${target}"
+    chmod +x "${target}"
+}
+
+function ensure_native_oha {
+    local asset
+    local target
+
+    if [[ -n "${OHA_BIN:-}" && -x "${OHA_BIN}" ]]; then
+        export OHA_BIN
+        return 0
+    fi
+
+    if command -v oha >/dev/null 2>&1; then
+        OHA_BIN="$(command -v oha)"
+        export OHA_BIN
+        return 0
+    fi
+
+    asset="$(oha_asset_name "$(uname -s)" "$(uname -m)")"
+    target=".tmp/tools/oha/v${OHA_VERSION}/oha"
+
+    download_oha_asset "${asset}" "${target}"
+
+    OHA_BIN="${target}"
+    export OHA_BIN
+}
+
+function ensure_docker_oha {
+    local asset
+    local docker_arch
+    local target
+    local tool_dir
+    local wrapper
+
+    docker_arch="$(docker info --format '{{.Architecture}}')"
+    asset="$(oha_asset_name "Linux" "${docker_arch}")"
+    tool_dir="$(pwd -P)/.tmp/tools/oha/v${OHA_VERSION}"
+    target="${tool_dir}/${asset}"
+    wrapper="${tool_dir}/oha-docker"
+
+    download_oha_asset "${asset}" "${target}"
+
+    cat > "${wrapper}" <<BASH
+#!/usr/bin/env bash
+set -o errexit
+exec docker run --rm --network "${PROJECT_NAME}_default" -v "${tool_dir}:/tools:ro" --entrypoint "/tools/${asset}" "${OHA_DOCKER_IMAGE}" "\$@"
+BASH
+    chmod +x "${wrapper}"
+
+    OHA_BIN="${wrapper}"
+    PROD_BUILD_BASE_URL="http://web:${APP_PORT}"
+    export OHA_BIN
+    export PROD_BUILD_BASE_URL
+}
+
+function ensure_oha {
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        ensure_docker_oha
+    else
+        ensure_native_oha
+    fi
+}
+
+function write_compose_override {
+    mkdir -p "$(dirname "${COMPOSE_OVERRIDE_FILE}")"
+
+    cat > "${COMPOSE_OVERRIDE_FILE}" <<'YAML'
+services:
+  web:
+    environment:
+      CI_SKIP_CONTENT_PULL: "${CI_SKIP_CONTENT_PULL}"
+      CONTENT_BASE_PATH: "${CONTENT_BASE_PATH}"
+      CONTENT_REPO_URL: "${CONTENT_REPO_URL}"
+      DATABASE_URL: "${DATABASE_URL:-}"
+      GITHUB_TOKEN: "${GITHUB_TOKEN:-}"
+      GITHUB_WEBHOOK_SECRET: "${GITHUB_WEBHOOK_SECRET}"
+      MIX_ENV: "${MIX_ENV}"
+      NODE_ENV: "${NODE_ENV}"
+      PORT: "${PORT}"
+      POSTGRES_DB: "${POSTGRES_DB}"
+      POSTGRES_HOST: "${POSTGRES_HOST}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_POOL: "${POSTGRES_POOL:-15}"
+      POSTGRES_PORT: "${POSTGRES_PORT}"
+      POSTGRES_USER: "${POSTGRES_USER}"
+      SECRET_KEY_BASE: "${SECRET_KEY_BASE}"
+      URL_HOST: "${URL_HOST}"
+      URL_PORT: "${URL_PORT}"
+      URL_SCHEME: "${URL_SCHEME}"
+      URL_STATIC_HOST: "${URL_STATIC_HOST:-}"
+YAML
+}
+
+function wait_for_postgres {
+    local attempts=60
+
+    until "${compose[@]}" exec -T postgres pg_isready -U "${POSTGRES_USER}" >/dev/null 2>&1; do
+        attempts=$((attempts - 1))
+
+        if [[ "${attempts}" -le 0 ]]; then
+            echo "fatal: postgres did not become ready" >&2
+            exit 1
+        fi
+
+        sleep 1
+    done
+}
+
+function wait_for_ready {
+    local start_ms="$1"
+    local attempts=60
+    local ready_url="http://127.0.0.1:${HOST_PORT}/readyz"
+    local end_ms
+
+    until curl -fsS "${ready_url}" >/dev/null; do
+        attempts=$((attempts - 1))
+
+        if [[ "${attempts}" -le 0 ]]; then
+            echo "fatal: release did not become ready at ${ready_url}" >&2
+            exit 1
+        fi
+
+        sleep 1
+    done
+
+    end_ms="$(now_ms)"
+    PROD_BUILD_READY_MS="$((end_ms - start_ms))"
+    export PROD_BUILD_READY_MS
+
+    echo "release ready in ${PROD_BUILD_READY_MS}ms"
+}
+
+trap cleanup EXIT
+
+require_command curl
+require_command docker
+require_command jq
+require_command openssl
+require_command perl
+
+if [[ ! -e .env ]]; then
+    cp .env.example .env
+fi
+
+export MIX_ENV=prod
+export NODE_ENV=production
+export POSTGRES_USER="${POSTGRES_USER:-portfolio}"
+export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
+export POSTGRES_DB="${POSTGRES_DB:-${POSTGRES_USER}}"
+export POSTGRES_HOST=postgres
+export POSTGRES_PORT=5432
+export POSTGRES_POOL="${POSTGRES_POOL:-15}"
+export PORT="${APP_PORT}"
+export URL_HOST="${URL_HOST:-localhost}"
+export URL_SCHEME="${URL_SCHEME:-http}"
+export URL_PORT="${URL_PORT:-${HOST_PORT}}"
+export SECRET_KEY_BASE="${SECRET_KEY_BASE:-$(openssl rand -hex 64)}"
+export GITHUB_WEBHOOK_SECRET="${GITHUB_WEBHOOK_SECRET:-ci-github-webhook-secret}"
+export CONTENT_REPO_URL="${CONTENT_REPO_URL:-https://example.invalid/personal-website-content.git}"
+export CONTENT_BASE_PATH="${CONTENT_BASE_PATH:-/app/priv/content}"
+export CI_SKIP_CONTENT_PULL=1
+export DOCKER_WEB_VOLUME="${DOCKER_WEB_VOLUME:-/tmp:/tmp}"
+export DOCKER_WEB_PORT_FORWARD="${DOCKER_WEB_PORT_FORWARD:-127.0.0.1:${HOST_PORT}}"
+export DOCKER_RESTART_POLICY=no
+export PROD_BUILD_APP_SHA="${APP_SHA}"
+export PROD_BUILD_BASE_URL="${PROD_BUILD_BASE_URL:-http://127.0.0.1:${HOST_PORT}}"
+
+ensure_oha
+write_compose_override
+
+"${compose[@]}" build web
+"${compose[@]}" up -d postgres
+wait_for_postgres
+
+"${compose[@]}" run --rm --no-deps --entrypoint /app/bin/portfolio web eval "Portfolio.Release.migrate()"
+"${compose[@]}" run --rm --no-deps --entrypoint /app/bin/portfolio web eval "Portfolio.Release.rollback(Portfolio.Repo, 1)"
+"${compose[@]}" run --rm --no-deps --entrypoint /app/bin/portfolio web eval "Portfolio.Release.migrate()"
+
+start_ms="$(now_ms)"
+"${compose[@]}" up -d web
+wait_for_ready "${start_ms}"
+
+ci/probe-routes.sh ci/last-run.json
+
+"${compose[@]}" exec -T web \
+    bin/portfolio rpc "IO.inspect({Application.spec(:portfolio, :vsn), length(Supervisor.which_children(Portfolio.Supervisor)), Ecto.Adapters.SQL.query!(Portfolio.Repo, \"SELECT 1\").num_rows})"
+
+ci/compare.sh ci/last-run.json ci/baseline.json
+ci/update-baseline.sh ci/last-run.json ci/baseline.json

--- a/ci/routes-known-broken.txt
+++ b/ci/routes-known-broken.txt
@@ -1,0 +1,1 @@
+# One route per line. Add a "# why:" comment when a route is temporarily exempt.

--- a/ci/update-baseline.sh
+++ b/ci/update-baseline.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+LAST_RUN_FILE="${1:-ci/last-run.json}"
+BASELINE_FILE="${2:-ci/baseline.json}"
+branch=""
+
+if branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null)"; then
+    :
+fi
+
+if [[ "${branch}" != "main" ]]; then
+    echo "baseline update skipped: current branch is '${branch:-detached}', not main"
+    exit 0
+fi
+
+if [[ ! -f "${LAST_RUN_FILE}" ]]; then
+    echo "fatal: last-run file not found: ${LAST_RUN_FILE}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${BASELINE_FILE}" ]]; then
+    echo "fatal: baseline file not found: ${BASELINE_FILE}" >&2
+    exit 1
+fi
+
+sha="$(git rev-parse HEAD)"
+tmp_file="$(mktemp)"
+
+jq \
+    --arg sha "${sha}" \
+    --slurpfile last "${LAST_RUN_FILE}" \
+    '
+    def median_array:
+      sort | if length == 0 then null else .[(length / 2 | floor)] end;
+
+    .schema_version = 1
+    | .runs_count = ((.runs_count // 0) + 1)
+    | .last_updated_main_sha = $sha
+    | .ready_ms_samples = (((.ready_ms_samples // []) + [{sha: $sha, value: $last[0].ready_ms}]) | .[-30:])
+    | .ready_ms_median = ([.ready_ms_samples[].value] | median_array)
+    | reduce ($last[0].routes | to_entries[]) as $route (.;
+        .routes[$route.key].samples = (
+          ((.routes[$route.key].samples // []) + [{
+            sha: $sha,
+            warm_p50_ms: $route.value.warm_p50_ms,
+            warm_p95_ms: $route.value.warm_p95_ms,
+            warm_p99_ms: $route.value.warm_p99_ms,
+            cold_first_ms: $route.value.cold_first_ms
+          }]) | .[-30:]
+        )
+        | .routes[$route.key].warm_p50_ms = ([.routes[$route.key].samples[].warm_p50_ms] | median_array)
+        | .routes[$route.key].warm_p95_ms = ([.routes[$route.key].samples[].warm_p95_ms] | median_array)
+        | .routes[$route.key].warm_p99_ms = ([.routes[$route.key].samples[].warm_p99_ms] | median_array)
+        | .routes[$route.key].cold_first_ms = ([.routes[$route.key].samples[].cold_first_ms] | median_array)
+      )
+    ' "${BASELINE_FILE}" > "${tmp_file}"
+
+mv "${tmp_file}" "${BASELINE_FILE}"
+jq . "${BASELINE_FILE}"

--- a/config/config.exs
+++ b/config/config.exs
@@ -62,6 +62,8 @@ config :portfolio, Portfolio.Mailer, adapter: Swoosh.Adapters.Local
 
 config :swoosh, :api_client, false
 
+config :tzdata, :autoupdate, :disabled
+
 import_config "#{Mix.env()}.exs"
 
 config :github_webhook,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -76,13 +76,17 @@ config :github_webhook, secret: github_webhook_secret
 
 config :portfolio, content_repo_url: System.get_env("CONTENT_REPO_URL")
 
-if config_env() == :prod do
-  config :portfolio, content_base_path: "app/priv/content"
-else
-  config :portfolio, content_base_path: "priv/content"
-end
+default_content_base_path =
+  if config_env() == :prod do
+    "/app/priv/content"
+  else
+    "priv/content"
+  end
 
-content_base_path = Application.get_env(:portfolio, :content_base_path)
+content_base_path =
+  System.get_env("CONTENT_BASE_PATH", default_content_base_path)
+
+config :portfolio, content_base_path: content_base_path
 
 config :portfolio, Portfolio.Content.FileManagement.Watcher,
-  paths: [System.get_env("CONTENT_BASE_PATH", "priv/content")]
+  paths: [content_base_path]

--- a/lib/portfolio_web/controllers/readiness_controller.ex
+++ b/lib/portfolio_web/controllers/readiness_controller.ex
@@ -1,0 +1,14 @@
+defmodule PortfolioWeb.ReadinessController do
+  @moduledoc false
+
+  use PortfolioWeb, :controller
+
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, _params) do
+    Ecto.Adapters.SQL.query!(Portfolio.Repo, "SELECT 1")
+
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(:ok, "ok")
+  end
+end

--- a/lib/portfolio_web/live/note_live/show.html.heex
+++ b/lib/portfolio_web/live/note_live/show.html.heex
@@ -1,14 +1,6 @@
 <.header>
   Note {@note.id}
   <:subtitle>This is a note record from your database.</:subtitle>
-  <:actions>
-    <.link
-      patch={~p"/admin/note/#{@note.url}/show/edit"}
-      phx-click={JS.push_focus()}
-    >
-      <.button>Edit note</.button>
-    </.link>
-  </:actions>
 </.header>
 
 <article class="u-grid col-span-12-children text-pretty text-balance mx-auto max-w-100">

--- a/lib/portfolio_web/router.ex
+++ b/lib/portfolio_web/router.ex
@@ -47,6 +47,10 @@ defmodule PortfolioWeb.Router do
     pipe_through :api
   end
 
+  scope "/", PortfolioWeb do
+    get "/readyz", ReadinessController, :index
+  end
+
   # Documentation route - add before other routes to bypass locale redirection
   scope "/docs" do
     pipe_through :browser

--- a/run
+++ b/run
@@ -105,6 +105,10 @@ function lint:shell {
     scripts+=("${script}")
   done < <(find bin -type f -print0)
 
+  while IFS= read -r -d '' script; do
+    scripts+=("${script}")
+  done < <(find ci -type f -name '*.sh' -print0 2>/dev/null)
+
   if command -v shellcheck >/dev/null 2>&1; then
     shellcheck "${scripts[@]}"
   else
@@ -378,7 +382,7 @@ function clean {
 function ci:install-deps {
     if command -v apt-get >/dev/null 2>&1; then
         sudo apt-get update
-        sudo apt-get install -y curl shellcheck
+        sudo apt-get install -y curl jq shellcheck
         return 0
     fi
 
@@ -489,6 +493,10 @@ function ci:acceptance-gate-bypass-check {
 
 function ci:acceptance-gate-bypass-check:test {
     bin/ci/acceptance-gate-bypass-check --test-fixtures
+}
+
+function ci:prod-build {
+    ci/prod-build.sh
 }
 
 function ci:run-all {

--- a/test/portfolio_web/controllers/readiness_controller_test.exs
+++ b/test/portfolio_web/controllers/readiness_controller_test.exs
@@ -1,0 +1,13 @@
+defmodule PortfolioWeb.ReadinessControllerTest do
+  @moduledoc false
+
+  use PortfolioWeb.ConnCase, async: true
+
+  describe "GET /readyz" do
+    test "returns ok after the database responds", %{conn: conn} do
+      conn = get(conn, ~p"/readyz")
+
+      assert text_response(conn, 200) == "ok"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a scheduled/PR prod-build workflow backed by `./run ci:prod-build`
- build the prod release with warnings-as-errors, run migration up/down/up, boot the release, check `/readyz`, probe canonical routes with `oha`, and seed rolling latency baseline data
- document the deployability/DX contract in ADR 0001 and update the running tracker

## Verification
- `./run ci:prod-build`
- `DC=run ./run ci:compile`
- `DC=run ./run ci:lint`
- `DC=run ./run ci:security-check`
- `DC=run ./run ci:test`
- `DC=run ./run ci:static-analysis`
- `./run ci:workflow-lint`
- `./run ci:acceptance-gate-bypass-check`
- `./run ci:acceptance-gate-bypass-check:test`
- `./run ci:secret-scan`