### PR TITLE
docs(ops): update deploy status plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   workflow-lint:
     name: "Workflow lint"

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: "prod-build-${{ github.ref }}"
   cancel-in-progress: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - "main"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release-please:
     runs-on: "ubuntu-22.04"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -9,6 +9,9 @@ on:
       - "main"
       - "master"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   gitleaks:
     runs-on: "ubuntu-22.04"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,9 @@ GitHub CI must expose the real acceptance gates as legible top-level check jobs.
 - `./run ci:static-analysis` is clean: Dialyzer reports `Total errors: 0, Skipped: 0, Unnecessary Skips: 0`.
 - `./run ci:test` is clean: Elixir tests and JS tests have 0 failures.
 - The secret-scan workflow runs `./run ci:secret-scan`; gitleaks current-tree scan has 0 findings.
+- `./run ci:prod-build` is clean: prod image build, migration round-trip, release boot, `/readyz`, canonical route probes, release RPC introspection, and perf-baseline comparison all pass. GitHub branch protection must require the top-level `Prod build` check.
 
-Route smoke is not an always-on acceptance gate yet. Do not add placeholder route smoke just to make CI look broader. A route or release smoke gate belongs in the production-build work after the app has a meaningful readiness/content contract.
+Route smoke is part of the production-build gate, not a separate placeholder job. Do not add another route-smoke gate just to make CI look broader; widen `./run ci:prod-build` only when the app has a stronger readiness/content contract.
 
 ### Gate integrity: no fake green
 
@@ -70,7 +71,7 @@ The Elixir-side prescriptions (writing-controllers, writing-liveviews, writing-o
 - **Why now:** The repo just emerged from a multi-year "Backup from broken mac" state. Deps current, code clean, deps cleared GitHub vulnerabilities, branch merged. The infra layer is the next thing needed before design / typography rewrite work.
 - **Done looks like:** A push to main triggers CI gates; if green, an image is built and deployed via blue/green at the origin; smoke test runs; rollback is one command and tested. Visitors never see broken (CDN-cached front absorbs origin restarts and outages). Origin runs on the smallest hardware that meets the app's measured needs. Content-repo updates flow through the same loop. Observability emits metrics/logs Z can see; the next deploy reacts (auto-cancel rollout if error rate spikes).
 - **Out of scope:** No Grafana. No tool/stack prescription without `/literature` first (CDN, secrets, deploy substrate, observability all queued).
-- **Who else:** visitors (uptime + speed); future-Z (returning months later, expects deploy = forget nothing); LLMs working in this repo (CI is their guardrail); content-repo automation (`personal-website-content` webhook is a deploy "user").
+- **Who else:** visitors (uptime + speed); future-Z (returning months later, expects deploy = forget nothing); LLMs working in this repo (CI is their guardrail); content-repo automation (`personal-site-content` webhook is a deploy "user"; earlier notes may call this `personal-website-content`).
 
 ### Vision
 
@@ -86,8 +87,8 @@ The breadboard-frame-as-painting is an aspiration, not a romantic floor. Owned h
 
 In approximate PM rank order. #1 anchors first — site is meaningless without content flowing through.
 
-1. **Content-pipeline sync.** Finish the `personal-website-content` webhook story. Currently partially wired (`Portfolio.Release.pull_repository`, `GitHubWebhook` plug). Site is meaningless without content flowing through.
-2. **CI gates.** LLM-mistake catcher. Largely orthogonal to where prod runs; can ship while #1 is in flight. Includes hardening lint/test/dialyzer gates already passing locally; build-and-cache the prod image; run smoke tests against it; perf budget if/when measured baseline exists.
+1. **Content-pipeline sync.** Finish the content-repo webhook story. The configured repo is `personal-site-content` in `.env.example`; earlier notes may call it `personal-website-content`. The app path is currently partially wired (`Portfolio.Release.pull_repository`, `GitHubWebhook` plug). Site is meaningless without content flowing through.
+2. **CI gates.** LLM-mistake catcher. Shipped 2026-05-07: existing compile/lint/security/test/static-analysis/workflow/secret gates are required, and `Prod build` is now a required branch-protection check. The gate builds the release image, runs migrations up/down/up, boots the release, checks `/readyz`, probes canonical routes, runs release RPC introspection, and records perf data.
 3. **Resource-frugality of the app itself.** Measure cold-start, p50 request latency, memory footprint, cache-hit rate. Reduce until "small enough." Cold-start audit at `.tmp/2026-05-05-upgrade-deep-dive/cold-start.md` is queued input. Hardware decision falls out of this measurement, not before.
 4. **Front-edge cache substrate.** CDN choice. Depends on #3 to know what's safely cacheable and TTL bounds. **Requires `/literature` before tool selection.**
 5. **Origin substrate + deploy pipeline.** Hardware + release format + blue/green at origin + deploy mechanics. Hardware falls out of #3. **Requires `/literature` before tool selection.**
@@ -98,6 +99,8 @@ The order is not fully ratified beyond #1; #2 explicitly parallelizes with #1; #
 ### Round-trip deploy definition
 
 The "round-trip" is the full loop: **push → CI gates → image build → blue/green deploy → smoke test → notify → tested rollback path exercised on every deploy → content-repo updates flowing through the same loop → observability emits metrics/logs the next deploy reacts to (auto-cancel on error-rate spike).** All four pieces (the basic loop, rollback, content sync, observability feedback) are in scope; this is what success looks like.
+
+Current Phase 3 status and sequencing live in `_PROJECT_DOCS/deploy-ops-status-plan.md`. Keep that plan synchronized with `_PROJECT_DOCS/2026-revival-todo.md` when the active workstream changes.
 
 ### Hard constraints (partial — Step 4 of `/grill-me` was cut short)
 

--- a/_PROJECT_DOCS/2026-revival-todo.md
+++ b/_PROJECT_DOCS/2026-revival-todo.md
@@ -2,7 +2,7 @@
 
 Started 2026-05-05 with the branch `frontend-infra` ("Backup from broken mac"). This doc tracks where we are in the bigger arc: get the repo working → clean it up → upgrade deps → merge to main → cold-start hardening → typography redesign.
 
-**Updated:** 2026-05-07 (prod-build/nightly CI gate implemented on `agent/prod-build-gate`; deploy substrate still pending).
+**Updated:** 2026-05-07 (prod-build/nightly CI gate merged, `Prod build` required in branch protection, release `v0.4.3` published; content-pipeline sync is next).
 
 ---
 
@@ -25,45 +25,27 @@ Started 2026-05-05 with the branch `frontend-infra` ("Backup from broken mac"). 
 | 2.6 — Push final to origin | ✅ done | All commits pushed; tag baseline `9053f70`. |
 | 2.7 — Triage GitHub vulnerabilities | ✅ done | All 213 historical npm alerts auto-resolved by the Group 5 upgrade (timestamps line up exactly with the push). 0 open, 0 hex/elixir-side advisories. The 48-figure on push was a stale snapshot. |
 | 3 — Deploy/ops scope | 🔄 **active** | `/grill-me` ran 2026-05-06. Vision + objectives + 6 strategies in `AGENTS.md`. Hard-constraints + taste-seeding cut short — re-run `/grill-me` next time. |
-| 3.1 — Content-pipeline sync | ⏸ next | `personal-website-content` webhook hardening. PM rank #1 — site is meaningless without content. |
-| 3.2 — CI gates | 🔄 in PR | Prod-build gate implemented: release build, migrations up/down/up, `/readyz`, route smoke, RPC introspection, rolling baseline seed, nightly schedule. Promote to required branch protection after the workflow is green on GitHub. |
-| 3.3 — Resource-frugality of the app | ⏸ pending | Measure cold-start, p50, memory, cache-hit rate. Cold-start audit at `.tmp/2026-05-05-upgrade-deep-dive/cold-start.md` queued. **Hardware decision falls out of this, not before.** |
-| 3.4 — Front-edge cache (CDN) | ⏸ pending | `/literature` required before tool selection. |
-| 3.5 — Origin substrate + deploy pipeline | ⏸ pending | `/literature` required. Hardware + blue/green + deploy mechanics. |
-| 3.6 — Observability + rollback loop | ⏸ pending | `/literature` required. No Grafana (Z veto). |
+| 3.1 — Content-pipeline sync | 🔄 active next | Make content push-to-main deterministic: authenticate webhook, validate repo/ref/after SHA, dedupe, sync exact commit, ingest/publish or reject, record accepted content SHA, keep last-good content on failure. See `_PROJECT_DOCS/deploy-ops-status-plan.md`. |
+| 3.2 — CI gates | ✅ done | `Prod build` merged in `v0.4.3` and required by branch protection. Gate covers release image build, migrations up/down/up, `/readyz`, route probes, release RPC introspection, rolling baseline seed, and nightly schedule. |
+| 3.3 — Resource-frugality of the app | ⏸ pending | Measure cold-start, p50, memory, cache-hit rate, and runtime footprint on the same ruler before choosing hardware. Cold-start audit at `.tmp/2026-05-05-upgrade-deep-dive/cold-start.md` queued. |
+| 3.4 — Front-edge cache (CDN) | ⏸ pending | `/literature` required before tool selection. Needs app/cacheability measurements first. |
+| 3.5 — Origin substrate + deploy pipeline | ⏸ planning-gated | `/literature` required before tool selection. Philosophy: versioned/idempotent blue-green deploy to the smallest measured-good origin; free/FLOSS and compute-per-watt win only after visitor speed and rollback reliability hold. |
+| 3.6 — Observability + rollback loop | ⏸ planning-gated | `/literature` required before tool selection. Minimum signal set and rollback policy need planning; No Grafana (Z veto). |
+| 3.7 — GitHub Actions Node 24 readiness | ✅ done | Workflows opt into `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` ahead of GitHub's Node 20 action runtime deadlines. |
 | 4 — Tier-2/3 audit followups | ⏸ pending | ~24 inventoried, ranked. Pick what's load-bearing. |
 | 5 — Typography redesign | ⏸ pending | Figma changes; JA/EN dynamic typography swap; optical alignment via `text-box-trim` (80% support) + existing fontkit polyfill. Touches `typography.ex`, `typography_helpers.ex`, the tailwind generator pipeline. |
 
 ---
 
-## Active workstream — Group 5 (JS-only deps)
+## Active workstream — Phase 3 deploy/ops
 
-In-flight as of this writing. Constraints:
-- Tailwind v3 stays (Z's ratification 2026-05-05 — cross-arch Docker bug + no daisyUI need + portfolio scale).
-- Skip new tooling; bump existing only.
-- Each version bump verified by `mix compile clean` + `vitest run` + route smoke + `mix test --seed 0`.
+Current order of operations:
 
-Bumping (per `assets/package.json`):
-- `@biomejs/biome` 1.9 → 2.4 (major)
-- `@vitest/*` + `vitest` 2.1 → 4.1 (two majors)
-- `esbuild` 0.23 → 0.28
-- `jsdom` 25 → 29 (forces Node base image bump from 22.9 to 22.21 in Dockerfile)
-- `playwright` 1.48 → 1.59
-- `postcss` 8.4 → 8.5; `postcss-import` 16.1.0 → 16.1.1
-- `prettier` 3.3 → 3.8
-- `stylelint` 16 → 17 (major); `stylelint-config-standard` 36 → 40 (major); `stylelint-config-tailwindcss` 0.0.7 → 1.0 (major)
-- `@types/fontkit` 2.0.7 → 2.0.9
-- `autoprefixer` 10.4 → 10.5
-- `topbar` 3.0.0 → 3.0.1
-
-Already done:
-- Node base image bumped 22.9 → 22.21 in Dockerfile (jsdom 29 needed it).
-
-Not yet done:
-- yarn install resolution + verify build works
-- vitest config compatibility with v4
-- biome config compatibility with v2
-- stylelint config compatibility with v17
+1. **Lock the shipped CI guardrail.** Done: `Prod build` is required in branch protection and release `v0.4.3` exercised the image build/publish path.
+2. **Make content deployment deterministic.** Replace "webhook triggers git pull and the watcher hopefully notices" with an explicit content promotion path: signed payload → expected repo/ref/after SHA → single sync lock → exact git sync → parse/ingest affected markdown → record accepted or rejected content SHA.
+3. **Measure before choosing origin hardware.** Use the prod-build vocabulary for live/local runs: time-to-ready, cold-first response, warm p50/p95, memory, CPU, and power where available.
+4. **Plan origin and edge only after measurements.** The philosophical constraint is smallest honest origin, free/FLOSS where viable, but visitor speed and rollback reliability are the floor.
+5. **Plan observability around deploy evidence.** Minimum useful signals: request health, release identity, content SHA, BEAM/runtime health, DB boundary, and cache/origin split after an edge substrate exists.
 
 ---
 

--- a/_PROJECT_DOCS/adrs/0001-prod-build-ci-gate.md
+++ b/_PROJECT_DOCS/adrs/0001-prod-build-ci-gate.md
@@ -1,6 +1,6 @@
 # ADR 0001 — Production-build CI gates
 
-**Status:** accepted 2026-05-07.
+**Status:** accepted 2026-05-07; implemented and promoted to required branch protection 2026-05-07.
 **Supersedes:** none.
 **Superseded by:** none.
 
@@ -20,7 +20,7 @@ There are four deployability levels:
 
 - **PR deployable**: the proposed app code passes acceptance gates, builds a prod release, boots with image-baked content, serves canonical routes, and stays inside the CI-side speed floor or baseline-drift policy.
 - **Release deployable**: the release tag creates an image that can be identified by tag, SHA, and digest; Release Please can merge only after the required gates pass.
-- **Content deployable**: a `personal-website-content` commit can be authenticated, deduped, synced, parsed, and either promoted or rejected without preventing the app from booting.
+- **Content deployable**: a content repo commit can be authenticated, deduped, synced, parsed, and either promoted or rejected without preventing the app from booting. The configured repo URL in `.env.example` currently points at `personal-site-content`; earlier planning notes may call this `personal-website-content`.
 - **Origin deployable**: the selected origin can pull or receive the release artifact, run migrations, flip blue/green, pass live smoke, and roll back to the last known-good app/content pair.
 
 This ADR implements the first level and prepares the second. Content and origin deployability remain follow-up work because they involve the webhook/sync path and the deploy substrate.
@@ -40,7 +40,7 @@ For release work:
 
 - Conventional commits feed Release Please.
 - Release Please opens or updates the release PR.
-- Auto-merge waits on the required gates, including `prod-build` once promoted to branch protection.
+- Auto-merge waits on the required gates, including `Prod build`.
 - A merged release creates an image tagged by release and commit SHA. Future deploy tooling consumes that identity, not a floating local build.
 
 For content work:

--- a/_PROJECT_DOCS/deploy-ops-status-plan.md
+++ b/_PROJECT_DOCS/deploy-ops-status-plan.md
@@ -1,0 +1,83 @@
+# Deploy / ops status and plan
+
+**Updated:** 2026-05-07.
+
+This is the working plan for Phase 3 after the production-build gate landed. It is not an ADR: it records status, sequencing, and what "done" should feel like from Z's DX.
+
+## Current status
+
+- `main` is current at release `v0.4.3`.
+- Branch protection requires `Workflow lint`, `Gate integrity`, `Compile`, `Lint`, `Security check`, `Test`, `Static analysis`, `gitleaks`, and `Prod build`.
+- `Prod build` runs on PRs, pushes to `main`, nightly schedule, and manual dispatch. It builds the prod image, runs migrations up/down/up, boots the release, waits for `/readyz`, probes canonical routes, runs release RPC introspection, compares perf data, and uploads measurements.
+- Release Please is automated enough for this pre-1.0 portfolio: conventional commits open release PRs, auto-merge waits on required gates, and release creation builds/pushes tagged images.
+- The content pipeline is still partial. Boot pulls content via `Portfolio.Release.pull_repository/0`; the webhook path triggers a git sync through `RemoteUpdateTrigger`, but content promotion is not a deterministic "sync exact commit, parse, record verdict" flow yet.
+- Origin deploy does not exist yet. There is a release image, but no selected origin, blue/green mechanism, live smoke, or rollback command.
+- Observability exists only as CI/deployability evidence. Runtime metrics/logs/alerts and auto-cancel-on-spike are not designed yet.
+- The configured content repo URL currently points at `personal-site-content`; earlier planning notes may call the separate content repo `personal-website-content`.
+
+## Next slice: content-pipeline DX
+
+Desired DX: edit content, run local content checks if useful, commit, push, then read a clear verdict: accepted and live, rejected with a parse/validation error, or ignored because no publishable content changed. No SSH, no container restart, no DB poking, no "did the watcher notice?" uncertainty.
+
+Smallest implementation slice:
+
+1. Validate signed GitHub push payloads against the expected repo, branch, and `after` SHA.
+2. Dedupe deliveries by content commit SHA.
+3. Acquire one content-sync lock so concurrent webhook deliveries cannot interleave.
+4. Sync the local content clone to the exact accepted SHA, not just floating `origin/main`.
+5. Parse and ingest the relevant markdown files through an explicit service path.
+6. Record accepted/rejected content SHA and reason.
+7. Keep serving the previous known-good content if sync or parsing fails.
+
+Known risks to address in that slice:
+
+- Webhook relevance ignores deleted markdown files.
+- Webhook sync currently returns success after git sync; it does not explicitly promote content.
+- Boot-time content pull can prevent the container from starting if GitHub or auth fails.
+- Private repo auth is configured but not wired into the git clone/fetch path.
+- Tests should use local fixture git repos rather than real network URLs.
+- Production frontmatter parsing needs review before content promotion becomes authoritative.
+
+## Origin deploy philosophy
+
+Do not choose hardware or ingress first. The order is measurement-led:
+
+1. Make content sync safe enough that origin restarts do not depend on upstream GitHub availability.
+2. Measure the app using the same vocabulary as `Prod build`: time-to-ready, cold-first response, warm p50/p95, memory, CPU, and power where available.
+3. Reduce app cost before buying or assigning hardware.
+4. Lock origin invariants before stack choice: immutable app image/release plus content SHA, runtime secrets, blue/green, pre-flip and post-flip smoke, one-command rollback, and content-only rollback.
+5. Run `/literature` for origin substrate only after measurements exist.
+
+Free/FLOSS and self-hostable tools are preferred when viable. They do not beat visitor speed, rollback reliability, or the "future-Z can reproduce this in a year" rule. Cloudflare Tunnel, Tailscale/tailnet paths, reverse proxy ingress, owned NUC/Mac/NAS hardware, and Pi-class hardware are candidates, not decisions.
+
+## Observability and rollback planning
+
+Minimum useful signal set:
+
+- Request health: status counts, 5xx rate, latency p50/p95/p99, route, method, request id.
+- Release identity: app version, git SHA/tag, image digest, content SHA, DB migration version.
+- Runtime health: boot, supervised child restarts, crash exits, memory, scheduler/CPU pressure, process count.
+- DB boundary: query failures, migration result, pool pressure if available.
+- Content pipeline: webhook accepted/rejected, HMAC failure, delivery dedupe, sync result, promoted content SHA, last-good content SHA.
+- Edge/origin split after CDN selection: cache hit/miss, stale responses, origin fallthrough, origin unreachable events.
+
+Rollback should act on deploy evidence:
+
+- Deploy promotes an immutable app/content pair, never `latest` by memory.
+- Blue/green smokes the inactive color before traffic flip and the active color after traffic flip.
+- Every deploy exercises rollback mechanics, even when it does not keep the rollback active.
+- Auto-cancel belongs to the rollout window or the next rollout. It must not weaken CI gates or hide failures.
+- Rollback has two scopes: app+content pair rollback and content-only rollback.
+
+Open planning questions:
+
+- Telemetry-leaving-box policy.
+- Notification destination for red nightly/deploy events.
+- Budget ceiling.
+- Network rule: tailnet-only admin? public tunnel? direct reverse proxy?
+- Key-management policy beyond existing `op://` conventions.
+- Why exactly Grafana is vetoed: UI, vendor, dashboard burden, Prometheus-style ops, or something else.
+
+## Node 20 actions cleanup
+
+GitHub warned that Node 20 JavaScript actions move to Node 24 defaults on 2026-06-02 and lose Node 20 runner support on 2026-09-16. The workflows now set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` so the repo tests the future runtime before the forced cutover.


### PR DESCRIPTION
**Summary**
- Records the current Phase 3 status now that `Prod build` is merged, required, and release `v0.4.3` exists.
- Adds `_PROJECT_DOCS/deploy-ops-status-plan.md` with the content-pipeline DX slice, measurement-led origin philosophy, and observability/rollback planning questions.
- Opts workflows into `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` ahead of GitHub's Node 20 action-runtime cutover.

**Verification**
- `./run ci:workflow-lint`
- `./run ci:acceptance-gate-bypass-check`
- `./run ci:acceptance-gate-bypass-check:test`
- `./run ci:secret-scan`
- `git diff --check`
- Branch protection required contexts verified through GitHub API include `Prod build`.

The two preexisting untracked docs were left untouched: `_PROJECT_DOCS/ci-prod-build-gate.md` and `_PROJECT_DOCS/handoff-prompt.md`.