### PR TITLE
feat(content): add content validation command

### DIFF
--- a/lib/mix/tasks/portfolio.content.validate.ex
+++ b/lib/mix/tasks/portfolio.content.validate.ex
@@ -1,0 +1,63 @@
+defmodule Mix.Tasks.Portfolio.Content.Validate do
+  @moduledoc """
+  Validates a checked-out portfolio content repository.
+
+  This task is intended for content-repo CI. It exercises the same promotion
+  path production uses, but rolls back the transaction so validation does not
+  publish or mutate persistent content state.
+  """
+
+  use Mix.Task
+
+  alias Portfolio.Content.FileManagement.Validator
+
+  @shortdoc "Validate publishable portfolio content"
+
+  @impl Mix.Task
+  @spec run([String.t()]) :: :ok | no_return()
+  def run([content_path]) do
+    Mix.Task.run("app.start")
+
+    content_path = Path.expand(content_path)
+
+    case Validator.validate_all(content_path) do
+      {:ok, result} ->
+        Mix.shell().info(success_message(content_path, result))
+
+      {:error, result} ->
+        Mix.shell().error(failure_message(content_path, result))
+        exit({:shutdown, 1})
+    end
+  end
+
+  def run(_args) do
+    Mix.raise("Usage: mix portfolio.content.validate CONTENT_PATH")
+  end
+
+  defp success_message(content_path, result) do
+    """
+    Content validation passed for #{content_path}
+    Promotable files: #{length(result.promoted)}
+    Removed entries if published: #{length(result.removed)}
+    Skipped paths: #{length(result.skipped)}
+    """
+  end
+
+  defp failure_message(content_path, result) do
+    errors =
+      result.errors
+      |> Enum.reverse()
+      |> Enum.map_join("\n", &format_error(content_path, &1))
+
+    """
+    Content validation failed for #{content_path}
+    Errors:
+    #{errors}
+    """
+  end
+
+  defp format_error(content_path, %{path: path, reason: reason}) do
+    display_path = Path.relative_to(path, content_path)
+    "- #{display_path}: #{inspect(reason)}"
+  end
+end

--- a/lib/portfolio/content/file_management/promoter.ex
+++ b/lib/portfolio/content/file_management/promoter.ex
@@ -14,6 +14,7 @@ defmodule Portfolio.Content.FileManagement.Promoter do
   alias Portfolio.Content.FileManagement.Reader
   alias Portfolio.Content.Schemas.CaseStudy
   alias Portfolio.Content.Schemas.Note
+  alias Portfolio.Content.Types
   alias Portfolio.Repo
 
   @type change_set :: %{
@@ -144,6 +145,7 @@ defmodule Portfolio.Content.FileManagement.Promoter do
         |> Path.wildcard()
         |> Enum.map(&Path.expand/1)
         |> Enum.reject(&hidden_path?/1)
+        |> Enum.filter(&publishable_markdown_path?/1)
         |> Enum.sort()
 
       {:ok, files}
@@ -283,6 +285,17 @@ defmodule Portfolio.Content.FileManagement.Promoter do
     path
     |> Path.split()
     |> Enum.any?(&String.starts_with?(&1, "."))
+  end
+
+  defp publishable_markdown_path?(path) do
+    content_slugs =
+      Types.content_types()
+      |> Map.values()
+      |> Enum.flat_map(& &1.slugs)
+
+    path
+    |> Path.split()
+    |> Enum.any?(&(&1 in content_slugs))
   end
 
   defp skip_path(result, path), do: %{result | skipped: [path | result.skipped]}

--- a/lib/portfolio/content/file_management/validator.ex
+++ b/lib/portfolio/content/file_management/validator.ex
@@ -1,0 +1,49 @@
+defmodule Portfolio.Content.FileManagement.Validator do
+  @moduledoc """
+  Validates a checked-out content repository without publishing it.
+
+  Validation intentionally reuses the same promotion path as production content
+  updates, then rolls the transaction back. A green result means the content can
+  be parsed, validated, compiled, and promoted by the app's current rules.
+  """
+
+  alias Portfolio.Content.FileManagement.Promoter
+  alias Portfolio.Repo
+
+  @type validation_result :: Promoter.promotion_result()
+
+  @doc """
+  Validates all publishable Markdown under `content_base_path`.
+  """
+  @spec validate_all(String.t()) ::
+          {:ok, validation_result()} | {:error, validation_result()}
+  def validate_all(content_base_path) when is_binary(content_base_path) do
+    content_base_path
+    |> Path.expand()
+    |> validate_in_rollback_transaction()
+  end
+
+  defp validate_in_rollback_transaction(content_base_path) do
+    case Repo.transaction(fn -> validate_and_rollback(content_base_path) end) do
+      {:error, {:valid, result}} -> {:ok, result}
+      {:error, {:invalid, result}} -> {:error, result}
+      {:error, reason} -> {:error, transaction_error(reason)}
+    end
+  end
+
+  defp validate_and_rollback(content_base_path) do
+    case Promoter.promote_all(content_base_path) do
+      {:ok, result} -> Repo.rollback({:valid, result})
+      {:error, result} -> Repo.rollback({:invalid, result})
+    end
+  end
+
+  defp transaction_error(reason) do
+    %{
+      promoted: [],
+      removed: [],
+      skipped: [],
+      errors: [%{path: "transaction", reason: reason}]
+    }
+  end
+end

--- a/run
+++ b/run
@@ -359,6 +359,32 @@ function prod:remote {
   cmd bin/portfolio remote
 }
 
+function content:validate {
+  # Validate a checked-out personal-site-content tree through the app promoter
+  local content_path
+  local content_path_abs
+
+  content_path="${1:-}"
+
+  if [[ -z "${content_path}" ]]; then
+    echo "Usage: ./run content:validate /path/to/personal-site-content"
+    return 1
+  fi
+
+  if [[ ! -d "${content_path}" ]]; then
+    echo "Content path does not exist or is not a directory: ${content_path}"
+    return 1
+  fi
+
+  content_path_abs="$(cd "${content_path}" && pwd)"
+
+  docker compose run --rm ${TTY} \
+    -v "${content_path_abs}:/content:ro" \
+    -e "MIX_ENV=test" \
+    web bash -lc \
+    "mix ecto.create --quiet && mix ecto.migrate --quiet && mix portfolio.content.validate /content"
+}
+
 function release {
   # Build and tag the Docker image
   docker build --no-cache -t portfolio:"$(git rev-parse --short HEAD) ."

--- a/test/portfolio/content/file_management/promoter_test.exs
+++ b/test/portfolio/content/file_management/promoter_test.exs
@@ -147,6 +147,23 @@ defmodule Portfolio.Content.FileManagement.PromoterTest do
   end
 
   describe "promote_all/1" do
+    test "ignores markdown outside publishable content paths" do
+      content_path = tmp_dir!("promote-all-ignore-docs")
+      on_exit(fn -> File.rm_rf!(content_path) end)
+
+      write_file!(content_path, "README.md", "# Content repo")
+      write_note!(content_path, "notes/published-note/en.md")
+
+      assert {:ok, result} = Promoter.promote_all(content_path)
+
+      assert result.promoted == [
+               Path.expand("notes/published-note/en.md", content_path)
+             ]
+
+      assert result.errors == []
+      assert %Note{} = Repo.get_by(Note, url: "published-note")
+    end
+
     test "prunes database entries whose source markdown disappeared" do
       content_path = tmp_dir!("promote-all-prune")
       on_exit(fn -> File.rm_rf!(content_path) end)

--- a/test/portfolio/content/file_management/validator_test.exs
+++ b/test/portfolio/content/file_management/validator_test.exs
@@ -1,0 +1,45 @@
+defmodule Portfolio.Content.FileManagement.ValidatorTest do
+  use Portfolio.DataCase, async: true
+
+  alias Portfolio.Content.FileManagement.Validator
+  alias Portfolio.Content.Schemas.Note
+  alias Portfolio.Repo
+
+  import Portfolio.ContentRepoHelpers
+
+  describe "validate_all/1" do
+    test "validates promotable content without persisting it" do
+      content_path = tmp_dir!("validate-all")
+      on_exit(fn -> File.rm_rf!(content_path) end)
+
+      write_note!(content_path, "notes/published-note/en.md")
+
+      assert {:ok, result} = Validator.validate_all(content_path)
+
+      assert result.promoted == [
+               Path.expand("notes/published-note/en.md", content_path)
+             ]
+
+      refute Repo.get_by(Note, url: "published-note")
+    end
+
+    test "returns promoter errors for invalid content" do
+      content_path = tmp_dir!("validate-invalid")
+      on_exit(fn -> File.rm_rf!(content_path) end)
+
+      write_invalid_note!(content_path, "notes/broken-note/en.md")
+
+      assert {:error, result} = Validator.validate_all(content_path)
+
+      assert [
+               %{
+                 path: invalid_path,
+                 reason: :invalid_markdown_format
+               }
+             ] = result.errors
+
+      assert invalid_path ==
+               Path.expand("notes/broken-note/en.md", content_path)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add rollback-only content validation using the production promoter path
- expose `mix portfolio.content.validate` and `./run content:validate <path>` for content-repo CI
- make full promotion ignore Markdown outside publishable content roots, so repo docs are not treated as site content

## Validation
- DC=run ./run elixir:test test/portfolio/content/file_management/promoter_test.exs test/portfolio/content/file_management/validator_test.exs
- ./run lint:shell
- git diff --check HEAD~1..HEAD
- ./run content:validate /Users/homelab/repos/personal-site-content currently fails only on publish-path content issues: two empty ja.md files and testing-case-study-malformed/en.md