### PR TITLE
Set up Buildx for private preview attestations

### DIFF
--- a/.github/workflows/private-preview-deploy.yml
+++ b/.github/workflows/private-preview-deploy.yml
@@ -61,6 +61,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: "Set up Docker Buildx"
+        uses: "docker/setup-buildx-action@v4"
+
       - name: "Build trusted preview browser check"
         run: docker build --target preview-page-acceptance -t personal-site-preview-page-acceptance:trusted .
 


### PR DESCRIPTION
Fixes the first real private-preview workflow run. GitHub's default Docker driver cannot emit provenance/SBOM attestations, so the candidate image build must use setup-buildx before docker/build-push-action.\n\nThis PR also contains the no-op candidate commit originally used to open the rehearsal PR; the only file change is the workflow fix.