### PR TITLE
Test redirects without blocking the footer email

### DIFF
--- a/ci/contracts/routes.json
+++ b/ci/contracts/routes.json
@@ -14,7 +14,12 @@
       "127.0.0.1",
       "0.0.0.0",
       "web:8000",
-      "zaneriley.com"
+      "http://zaneriley.com",
+      "https://zaneriley.com",
+      "http://www.zaneriley.com",
+      "https://www.zaneriley.com",
+      "//zaneriley.com",
+      "//www.zaneriley.com"
     ]
   },
   "browser": {

--- a/ci/preview/runtime-viability-test.sh
+++ b/ci/preview/runtime-viability-test.sh
@@ -101,6 +101,7 @@ assert_contains "${script_dir}/runtime-viability.sh" "CONTENT_REPO_URL=file:///a
 assert_contains "${script_dir}/runtime-viability.sh" "PREVIEW_DEPLOY_ATTEMPT_ID=\${PREVIEW_DEPLOY_ATTEMPT_ID:-}"
 assert_contains "${script_dir}/runtime-viability.sh" "prepare_content_source_repo"
 assert_contains "${script_dir}/runtime-viability.sh" "redact_public_preview_urls_in_text_artifacts"
+assert_contains "${script_dir}/runtime-viability.sh" "curl -L -sS -o"
 
 routes_file="${script_dir}/../contracts/routes.json"
 assert_json "${routes_file}" '.schema_version == 1'
@@ -109,6 +110,8 @@ assert_json "${routes_file}" '.routes | any(.path == "/en/case-study/prod-build-
 assert_json "${routes_file}" '.routes | any(.path == "/en/note/this-route-cannot-exist-xyzzy" and (.allowed_statuses | index(404)))'
 assert_json "${routes_file}" '.text_policy.forbidden_visible_text | index("We ran into an issue loading this note")'
 assert_json "${routes_file}" '.text_policy.forbidden_html_text | index("web:8000")'
+assert_json "${routes_file}" '.text_policy.forbidden_html_text | index("https://zaneriley.com")'
+assert_json "${routes_file}" '.text_policy.forbidden_html_text | index("zaneriley.com") == null'
 assert_json "${routes_file}" '[.routes[] | select((.browser.enabled // true) != false)] | length > 0'
 
 echo "runtime viability input test passed"

--- a/ci/preview/runtime-viability.sh
+++ b/ci/preview/runtime-viability.sh
@@ -551,7 +551,7 @@ function probe_routes {
         allowed_statuses_json="$(jq -c '.allowed_statuses' <<< "${route_json}")"
         required_body_text_json="$(jq -c '.required_body_text // []' <<< "${route_json}")"
         body_file="$(mktemp)"
-        status_code="$(curl -sS -o "${body_file}" -w "%{http_code}" "http://127.0.0.1:${RUNTIME_VIABILITY_HOST_PORT}${route}" || true)"
+        status_code="$(curl -L -sS -o "${body_file}" -w "%{http_code}" "http://127.0.0.1:${RUNTIME_VIABILITY_HOST_PORT}${route}" || true)"
         status_number="null"
         byte_count="$(wc -c < "${body_file}" | tr -d ' ')"
         required_body_text_present_json="$(literal_hits "${body_file}" "${required_body_text_json}")"


### PR DESCRIPTION
Fixes the private-preview route contract exposed by run 25981497228. Runtime route probing now follows redirects like the prod route probe, and the forbidden HTML contract blocks absolute production origins instead of the legitimate footer email domain.