### PR TITLE
Stop preview error pages from pointing at localhost

### DIFF
--- a/ci/contracts/routes.json
+++ b/ci/contracts/routes.json
@@ -167,7 +167,7 @@
       "label": "missing-note",
       "path": "/en/note/this-route-cannot-exist-xyzzy",
       "allowed_statuses": [404],
-      "required_body_text": ["Not Found"],
+      "required_body_text": ["ERROR 404", "DATA NOT FOUND"],
       "load_probe": {
         "enabled": false
       },

--- a/lib/portfolio_web/controllers/error_html.ex
+++ b/lib/portfolio_web/controllers/error_html.ex
@@ -30,15 +30,6 @@ defmodule PortfolioWeb.ErrorHTML do
     def actions(_exception), do: []
   end
 
-  def dynamic_home_url do
-    scheme = Application.get_env(:portfolio, :url_scheme, "http")
-    host = Application.get_env(:portfolio, :url_host, "localhost")
-    port = Application.get_env(:portfolio, :url_port, "8000")
-
-    port_segment = if port in ["80", "443"], do: "", else: ":#{port}"
-    "#{scheme}://#{host}#{port_segment}"
-  end
-
   def render(embed_template, _assigns) do
     Phoenix.Controller.status_message_from_template(embed_template)
   end

--- a/lib/portfolio_web/controllers/error_html/404.html.heex
+++ b/lib/portfolio_web/controllers/error_html/404.html.heex
@@ -51,7 +51,7 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:image"
-      content={PortfolioWeb.SiteOrigin.absolute_url("/images/og-default.png")}
+      content={~p"/images/og-default.png"}
     />
     <meta
       property="og:description"
@@ -70,7 +70,7 @@
     />
     <meta
       name="twitter:image"
-      content={PortfolioWeb.SiteOrigin.absolute_url("/images/og-default.png")}
+      content={~p"/images/og-default.png"}
     />
     <!-- FUll CSS -->
     <link phx-track-static rel="stylesheet" href={~p"/css/app.css"} />
@@ -91,8 +91,8 @@
         style="filter: url('#waves');transform: translateY(-0.25rem) translateX(calc(0rem));"
       >
         /********************************************** <br />
-        <a href="/" class="" aria-label={gettext("Return to homepage")}>
-          {dynamic_home_url()}
+        <a href={~p"/"} class="" aria-label={gettext("Return to homepage")}>
+          /
         </a>
         <h1>
           {gettext("ERROR 404")} <br /> {gettext("DATA NOT FOUND")}

--- a/lib/portfolio_web/controllers/error_html/500.html.heex
+++ b/lib/portfolio_web/controllers/error_html/500.html.heex
@@ -51,7 +51,7 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:image"
-      content={PortfolioWeb.SiteOrigin.absolute_url("/images/og-default.png")}
+      content={~p"/images/og-default.png"}
     />
     <meta
       property="og:description"
@@ -70,7 +70,7 @@
     />
     <meta
       name="twitter:image"
-      content={PortfolioWeb.SiteOrigin.absolute_url("/images/og-default.png")}
+      content={~p"/images/og-default.png"}
     />
     <link phx-track-static rel="stylesheet" href={~p"/css/critical.css"} />
     <!-- FUll CSS -->
@@ -92,8 +92,8 @@
         style="filter: url('#waves');transform: translateY(-0.25rem) translateX(calc(0rem));"
       >
         /********************************************** <br />
-        <a href="/" class="" aria-label="Return to homepage">
-          {dynamic_home_url()}
+        <a href={~p"/"} class="" aria-label="Return to homepage">
+          /
         </a>
         <h1>ERROR 500 <br /> INTERNAL SERVER ERROR</h1>
         * SYSTEM: Zane's Design Portfolio <br />

--- a/test/portfolio_web/controllers/error_html.test.exs
+++ b/test/portfolio_web/controllers/error_html.test.exs
@@ -5,12 +5,18 @@ defmodule PortfolioWeb.ErrorHTMLTest do
   import Phoenix.Template
 
   test "renders 404.html" do
-    assert render_to_string(PortfolioWeb.ErrorHTML, "404", "html", []) ==
-             "Not Found"
+    html = render_to_string(PortfolioWeb.ErrorHTML, "404", "html", [])
+
+    assert html =~ "ERROR 404"
+    assert html =~ "DATA NOT FOUND"
+    refute html =~ "localhost"
   end
 
   test "renders 500.html" do
-    assert render_to_string(PortfolioWeb.ErrorHTML, "500", "html", []) ==
-             "Internal Server Error"
+    html = render_to_string(PortfolioWeb.ErrorHTML, "500", "html", [])
+
+    assert html =~ "ERROR 500"
+    assert html =~ "INTERNAL SERVER ERROR"
+    refute html =~ "localhost"
   end
 end

--- a/test/portfolio_web/router_test.exs
+++ b/test/portfolio_web/router_test.exs
@@ -23,7 +23,11 @@ defmodule PortfolioWeb.RouterTest do
   describe "Error Handling Tests" do
     test "returns 404 for non-existent routes", %{conn: conn} do
       conn = get(conn, "/non-existent-route")
-      assert conn.status == 404
+      html = html_response(conn, 404)
+
+      assert html =~ "ERROR 404"
+      assert html =~ "DATA NOT FOUND"
+      refute html =~ "localhost"
     end
   end
 end


### PR DESCRIPTION
Fixes the remaining private-preview route failure from run 25981859414. The 404/500 templates now use root-relative home and image URLs instead of stale localhost-derived absolute URLs, and the route contract checks the actual 404 page copy.