### PR TITLE
Let the preview browser check write screenshots

### DIFF
--- a/run
+++ b/run
@@ -755,6 +755,7 @@ function ci:preview-page-acceptance {
     fi
 
     mkdir -p "${output_dir}"
+    chmod ugo+rwx "${output_dir}"
 
     docker run --rm \
         --init \


### PR DESCRIPTION
Fixes the next private-preview blocker from run 25982232218. The one-shot browser check runs as the container node user, so the generated artifact directory must be writable before it is mounted at /artifacts.