### PR TITLE
Keep compose exec from consuming content rehearsal script

### DIFF
--- a/ci/content-publication/rehearse-preview.sh
+++ b/ci/content-publication/rehearse-preview.sh
@@ -348,7 +348,7 @@ function wrong_signature_payload {
 }
 
 function content_status {
-    compose exec -T web /app/bin/content status --json
+    compose exec -T web /app/bin/content status --json </dev/null
 }
 
 load_env


### PR DESCRIPTION
Fixes the content publication rehearsal failure from run 25984740186. The rehearsal runs a remote SSH heredoc; docker compose exec reads stdin by default, so the content status probe could consume the rest of the remote script and leave the phase receipt empty.\n\nVerification:\n- ./run lint:shell\n- ./run ci:disposable-host-check